### PR TITLE
Fixing the failing tests from Simon and me

### DIFF
--- a/truffle/migrations/2_deploy_contracts.js
+++ b/truffle/migrations/2_deploy_contracts.js
@@ -1,4 +1,4 @@
-const ZombieAttack = artifacts.require("zombieattack");
+const ZombieAttack = artifacts.require("ZombieAttack");
 const SafeMath = artifacts.require("SafeMath");
 const { updateContracts } = require('../../web3/addresses/contracts');
 

--- a/truffle/test/TestZombieFactory.sol
+++ b/truffle/test/TestZombieFactory.sol
@@ -5,7 +5,7 @@ import "truffle/DeployedAddresses.sol";
 import "../contracts/zombieFactory.sol";
 
 // Inherit since we want to test internal functions
-contract TestZombiefactory is ZombieFactory {
+contract TestZombieFactory is ZombieFactory {
 	
 	function testZombieCreation() public {
 		string memory name = "Test";

--- a/truffle/test/test_zombieAttack.js
+++ b/truffle/test/test_zombieAttack.js
@@ -1,4 +1,4 @@
-const ZombieAttack = artifacts.require("./zombieattack.sol");
+const ZombieAttack = artifacts.require("ZombieAttack");
 
 contract('ZombieAttack', (accounts) => {
     const account_one = accounts[0];

--- a/truffle/test/test_zombieFactory.js
+++ b/truffle/test/test_zombieFactory.js
@@ -1,4 +1,4 @@
-var ZombieFactory = artifacts.require("./ZombieFactory.sol");
+var ZombieFactory = artifacts.require("ZombieAttack");
 
 contract("ZombieFactory", function(accounts) {
 

--- a/truffle/test/test_zombieHelper.js
+++ b/truffle/test/test_zombieHelper.js
@@ -1,5 +1,4 @@
-
-let ZombieHelper = artifacts.require("./ZombieAttack.sol");
+let ZombieHelper = artifacts.require("ZombieAttack");
 
 contract("ZombieHelper", (accounts) => {
     let account_one = accounts[0];


### PR DESCRIPTION
Fixing the failing tests boiled down (for me at least) to changing artifacts.require(...) from "contract.sol" to "ZombieAttack", since we only deploy that contract.
See also [https://github.com/trufflesuite/truffle/issues/552](https://github.com/trufflesuite/truffle/issues/552).

Also, at least for our solidity version, the test file has to have the same name as the test contract.

Hopefully this fixes the problems!